### PR TITLE
Finally Edge Selection and Lollipop like intersection

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
     <script src="src/camera.js"></script>
     <script src="src/initialize.js"></script>
     <script src="src/renderer.js"></script>
+    <script src="src/mousePicking.js"></script>
+    <script src="src/edgeInfo.js"></script>
     <script src="src/input.js" defer></script>
     <script src="src/debug.js"></script>
     <script src="src/menu.js" defer></script>
@@ -32,10 +34,6 @@
             <input type="file" id="fileInput" accept=".off">
             <label for="fileInput" class="file-input-label">Load OFF File</label>
         </div>
-        <div id="edgeInputWrapper">
-            <label for="edgeSelect">Edge Number: </label>
-            <input type="number" id="edgeSelect" min="1" value="1">
-        </div>
         <div class="fps-controls">
             <button id="fpsToggleButton" class="fps-button">Start FPS Counter</button>
             <div id="fpsDisplay" class="fps-display">FPS: --</div>
@@ -47,11 +45,46 @@
         <h3>Controls:</h3>
         <ul>
             <li><strong>Mouse drag:</strong> Rotate camera</li>
+            <li><strong>Mouse click:</strong> Select/deselect edges</li>
             <!-- <li><strong>Shift + Mouse Drag:</strong> Translate/pan view</li> -->
             <li><strong>Mouse wheel:</strong> Zoom in/out</li>
             <!-- <li><strong>Reset button (Ctrl):</strong> Return to center</li> -->
         </ul>
-    </div>    <div id="status" class="status"></div>
+    </div>    <!-- Edge Information Window -->
+    <div id="edgeInfoPanel" class="edge-info-panel collapsed">
+        <div class="edge-info-header" id="edgeInfoHeader">
+            <span class="edge-info-title">Edge Information</span>
+            <button class="edge-info-toggle" id="edgeInfoToggle">▼</button>
+        </div>
+        <div class="edge-info-content" id="edgeInfoContent">
+            <div class="edge-info-item">
+                <strong>Edge Number:</strong> <span id="edgeNumber">-</span>
+            </div>
+            <div class="edge-info-item">
+                <strong>From Vertex:</strong> <span id="fromVertex">-</span>
+            </div>
+            <div class="edge-info-item">
+                <strong>To Vertex:</strong> <span id="toVertex">-</span>
+            </div>
+            <div class="edge-info-item">
+                <strong>From Type:</strong> <span id="fromVertexType">-</span>
+            </div>
+            <div class="edge-info-item">
+                <strong>To Type:</strong> <span id="toVertexType">-</span>
+            </div>
+            <div class="edge-info-item">
+                <strong>From Value:</strong> <span id="fromVertexValue">-</span>
+            </div>
+            <div class="edge-info-item">
+                <strong>To Value:</strong> <span id="toVertexValue">-</span>
+            </div>
+            <div class="edge-info-item">
+                <strong>Connection Type:</strong> <span id="connectionType">L-shaped</span>
+            </div>
+        </div>
+    </div>
+
+    <div id="status" class="status"></div>
     <canvas id="canvas"></canvas>
     <script>
         const _c = document.getElementsByTagName('canvas')[0];

--- a/parameters.json
+++ b/parameters.json
@@ -15,11 +15,6 @@
       0.8,
       0.8
     ],
-    "lightColor": [
-      1,
-      1,
-      1
-    ],
     "nodeColors": {
       "minimum": [
         0,
@@ -42,13 +37,6 @@
         0.8
       ]
     }
-  },
-  "lighting": {
-    "lightPosition": [
-      10,
-      10,
-      10
-    ]
   },
   "controls": {
     "mouseSensitivity": 0.005

--- a/resources/pipeShader.frag
+++ b/resources/pipeShader.frag
@@ -1,8 +1,6 @@
 #version 300 es
 precision highp float;
 
-uniform vec3 uLightPos;
-uniform vec3 uLightColor;
 uniform mat4 uModelMatrix;
 uniform mat4 uViewMatrix;
 uniform mat4 uProjectionMatrix;
@@ -28,14 +26,14 @@ void main() {
     vec3 rayOrigin = vCameraPos;
     vec3 rayDir = normalize(vWorldPos - vCameraPos);
     
-    // Ray-cylinder intersection in world space
+    // ProteinVis-style ray-cylinder intersection
     vec3 oc = rayOrigin - vCylStart;
-    vec3 proj_oc = oc - dot(oc, cylDir) * cylDir;
-    vec3 proj_ray = rayDir - dot(rayDir, cylDir) * cylDir;
+    float rayDotCyl = dot(rayDir, cylDir);
+    float ocDotCyl = dot(oc, cylDir);
     
-    float a = dot(proj_ray, proj_ray);
-    float b = 2.0 * dot(proj_oc, proj_ray);
-    float c = dot(proj_oc, proj_oc) - vRadius * vRadius;
+    float a = dot(rayDir, rayDir) - rayDotCyl * rayDotCyl;
+    float b = 2.0 * (dot(oc, rayDir) - ocDotCyl * rayDotCyl);
+    float c = dot(oc, oc) - ocDotCyl * ocDotCyl - vRadius * vRadius;
     
     float discriminant = b * b - 4.0 * a * c;
     if (discriminant < 0.0) {
@@ -49,7 +47,9 @@ void main() {
     
     if (t <= 0.0) {
         discard;
-    }    // Calculate intersection point
+    }
+    
+    // Calculate intersection point
     vec3 hitPoint = rayOrigin + t * rayDir;
     float distAlongAxis = dot(hitPoint - vCylStart, cylDir);
 
@@ -123,10 +123,9 @@ void main() {
     vec4 clipPos = uProjectionMatrix * vec4(viewSpacePoint, 1.0);
     gl_FragDepth = (clipPos.z / clipPos.w + 1.0) * 0.5;
     
-    // === LIGHTING (ProteinVis style) ===
-    // For camera-attached light, use a fixed offset in view space to create moving specular
-    // This simulates a headlamp slightly above and to the right of the camera
-    vec3 viewLightPos = vec3(1, 4, 5); // Fixed position in view space
+    // === LIGHTING (Camera-based headlamp) ===
+    // Light position offset from camera in view space to avoid centered specular highlight
+    vec3 viewLightPos = vec3(1.0, 4.0, 5.0); // Fixed offset in view space
     
     // Transform normal to view space for lighting calculations
     vec3 viewNormal = normalize((uViewMatrix * uModelMatrix * vec4(cylinderNormal, 0.0)).xyz);
@@ -136,12 +135,17 @@ void main() {
     vec3 viewDir = normalize(-viewSpacePoint); // From surface to camera (origin) in view space
     vec3 halfVector = normalize(lightDir + viewDir);
     
-    // Blinn-Phong lighting with ProteinVis parameters
+    // Blinn-Phong lighting matching sphere shader
     float diffuse = max(0.0, dot(viewNormal, lightDir));
-    float specular = pow(max(0.0, dot(viewNormal, halfVector)), 64.0);
+    float specular = pow(max(0.0, dot(viewNormal, halfVector)), 32.0);
     
-    // ProteinVis lighting formula: ambient(0.2) + diffuse(0.5) + specular(0.3) to match sphere
-    vec3 finalColor = vInstanceColor * (0.25 + 0.5 * diffuse) + vec3(1.0, 1.0, 1.0) * 0.6 * specular;
+    // Consistent lighting formula with sphere shader
+    vec3 baseColor = vInstanceColor;
+    vec3 ambient = baseColor * 0.3;
+    vec3 diffuseColor = baseColor * diffuse * 0.5;
+    vec3 specularColor = vec3(1.0) * specular * 0.6;
+    
+    vec3 finalColor = ambient + diffuseColor + specularColor;
     
     fragColor = vec4(finalColor, 1.0);
 }

--- a/resources/sphereShader.frag
+++ b/resources/sphereShader.frag
@@ -1,7 +1,5 @@
 #version 300 es
 precision highp float;
-uniform vec3 uLightPos;
-uniform vec3 uLightColor;
 uniform mat4 uModelMatrix;
 uniform mat4 uViewMatrix;
 uniform mat4 uProjectionMatrix;
@@ -10,85 +8,56 @@ in vec2 vTexCoord;
 in vec3 vWorldPos;
 in vec3 vInstanceColor;
 in vec3 vInstanceCenter;
-in vec3 vCameraPos;
 in float vInstanceRadius;
 
 out vec4 fragColor;
 
 void main() {
-    // Map texture coordinates to [-1, 1] range, centered at (0.5, 0.5)
     vec2 uv = (vTexCoord - vec2(0.5)) * 2.0;
     float distFromCenter = length(uv);
     
-    // Discard fragments outside the sphere's circular boundary
     if (distFromCenter > 1.0) {
         discard;
     }
 
-    // Convert world positions to view space for calculations (like ProteinVis)
+    // TRY: Use the SAME coordinate transformation as the ray-casting version
     vec4 viewCenter = uViewMatrix * uModelMatrix * vec4(vInstanceCenter, 1.0);
     vec4 viewWorldPos = uViewMatrix * uModelMatrix * vec4(vWorldPos, 1.0);
     
-    // Create ray in view space from eye (0,0,0) through fragment
-    vec3 rayOrigin = vec3(0.0, 0.0, 0.0); // Eye is at origin in view space
-    vec3 rayDirection = normalize(viewWorldPos.xyz);
+    // Direct sphere calculation
+    float distFromCenterSq = dot(uv, uv);
+    float z = sqrt(max(0.0, 1.0 - distFromCenterSq));
     
-    // Sphere center and radius in view space
-    vec3 sphereCenter = viewCenter.xyz;
-    float sphereRadius = vInstanceRadius;
+    // Position on sphere surface in view space
+    vec3 sphereOffset = vec3(uv.x, uv.y, z) * vInstanceRadius;
+    vec3 viewHitPos = viewCenter.xyz + sphereOffset;
     
-    // Ray-sphere intersection using quadratic formula
-    // Ray: P = rayOrigin + t * rayDirection  
-    // Sphere: |P - center|² = radius²
-    vec3 oc = rayOrigin - sphereCenter;
-    float a = dot(rayDirection, rayDirection);
-    float b = 2.0 * dot(oc, rayDirection);
-    float c = dot(oc, oc) - sphereRadius * sphereRadius;
-    float discriminant = b * b - 4.0 * a * c;
-    
-    // No intersection if discriminant is negative
-    if (discriminant < 0.0) {
-        discard;
-    }
-      // Calculate intersection points in view space
-    float sqrtDiscriminant = sqrt(discriminant);
-    float t1 = (-b - sqrtDiscriminant) / (2.0 * a); // Near intersection
-    float t2 = (-b + sqrtDiscriminant) / (2.0 * a); // Far intersection
-    
-    // Use the closest positive intersection (front face of sphere)
-    float t = (t1 > 0.0) ? t1 : t2;
-    if (t <= 0.0) {
-        discard;
-    }
-      // Calculate intersection point in view space
-    vec3 viewHitPos = rayOrigin + t * rayDirection;
-    
-    // Calculate surface normal in view space (ProteinVis style)
-    vec3 viewNormal = normalize(viewHitPos - sphereCenter);
-    
-    // === DEPTH CALCULATION (ProteinVis style) ===
+    // TRY: Use the SAME depth calculation as ray-casting version
     vec4 clipHitPos = uProjectionMatrix * vec4(viewHitPos, 1.0);
     float ndcDepth = clipHitPos.z / clipHitPos.w;
-    gl_FragDepth = (ndcDepth + 1.0) * 0.5; // Convert from [-1,1] to [0,1]
+    gl_FragDepth = (ndcDepth + 1.0) * 0.5; // Same as ray-casting version
     
-    // === LIGHTING (ProteinVis style) ===
-    // For camera-attached light, use a fixed offset in view space to create moving specular
-    // This simulates a headlamp slightly above and to the right of the camera
-    vec3 viewLightPos = vec3(1, 4, 5); // Fixed position in view space
+    // Surface normal points outward from sphere center
+    vec3 viewNormal = normalize(sphereOffset);
     
-    // Calculate lighting vectors in view space
+    // Blinn-Phong lighting (Camera-based headlamp)
+    // Light position offset from camera in view space to avoid centered specular highlight
+    vec3 viewLightPos = vec3(1.0, 4.0, 5.0); // Fixed offset in view space
+    
     vec3 lightDir = normalize(viewLightPos - viewHitPos);
-    vec3 viewDir = normalize(-viewHitPos); // From surface to camera (origin) in view space
+    vec3 viewDir = normalize(-viewHitPos);
     vec3 halfVector = normalize(lightDir + viewDir);
     
-    // ProteinVis lighting model: much lower ambient, proper diffuse/specular balance
     float diffuse = max(0.0, dot(viewNormal, lightDir));
-    float specular = pow(max(0.0, dot(viewNormal, halfVector)), 64.0);
+    float specular = pow(max(0.0, dot(viewNormal, halfVector)), 32.0);
     
-    // ProteinVis lighting formula: low ambient + diffuse color + white specular
-    vec3 finalColor = vInstanceColor * (0.25 + 0.5 * diffuse) + vec3(1.0, 1.0, 1.0) * 0.6 * specular;
+    // Consistent Blinn-Phong lighting
+    vec3 baseColor = vInstanceColor;
+    vec3 ambient = baseColor * 0.3;
+    vec3 diffuseColor = baseColor * diffuse * 0.5;
+    vec3 specularColor = vec3(1.0) * specular * 0.6;
+    
+    vec3 finalColor = ambient + diffuseColor + specularColor;
     
     fragColor = vec4(finalColor, 1.0);
-
-    
 }

--- a/src/camera.js
+++ b/src/camera.js
@@ -46,8 +46,8 @@ function calculateUpVector() {
 function initializeCamera(vertices) {
     const bbox = calculateBoundingBox(vertices);
     
-    // Set camera target to the center of the bounding box
-    cameraTarget = [...bbox.center];
+    // Set camera target to the origin
+    cameraTarget = [0, 0, 0];
     
     // Set initial camera distance based on the largest dimension
     const maxDimension = Math.max(...bbox.size);

--- a/src/debug.js
+++ b/src/debug.js
@@ -10,8 +10,6 @@ function debugUniforms() {
         uProjectionMatrix: gl.getUniformLocation(sphereProgram, "uProjectionMatrix"),
         uViewMatrix: gl.getUniformLocation(sphereProgram, "uViewMatrix"),
         uModelMatrix: gl.getUniformLocation(sphereProgram, "uModelMatrix"),
-        uLightPos: gl.getUniformLocation(sphereProgram, "uLightPos"),
-        // uViewPos: gl.getUniformLocation(sphereProgram, "uViewPos"),
         uCameraPosLocation: gl.getUniformLocation(sphereProgram, "uCameraPos"),
         uColorLocation: gl.getUniformLocation(sphereProgram, "uColor")
     };
@@ -21,15 +19,13 @@ function debugUniforms() {
         uProjectionMatrix: gl.getUniformLocation(pipeProgram, "uProjectionMatrix"),
         uViewMatrix: gl.getUniformLocation(pipeProgram, "uViewMatrix"),
         uModelMatrix: gl.getUniformLocation(pipeProgram, "uModelMatrix"),
-        uLightPos: gl.getUniformLocation(pipeProgram, "uLightPos"),
         uColor: gl.getUniformLocation(pipeProgram, "uColor"),
         uCameraPosLocationPipe: gl.getUniformLocation(pipeProgram, "uCameraPos")
-        // Removed uViewPos since we're using uCameraPos directly in renderGraph
     };
 
     // Check if all expected uniforms exist
-    const expectedSphereUniforms = ["uProjectionMatrix", "uViewMatrix", "uModelMatrix", "uLightPos", "uCameraPos", "uColor"];
-    const expectedPipeUniforms = ["uProjectionMatrix", "uViewMatrix", "uModelMatrix", "uLightPos", "uColor", "uCameraPos"];
+    const expectedSphereUniforms = ["uProjectionMatrix", "uViewMatrix", "uModelMatrix", "uCameraPos", "uColor"];
+    const expectedPipeUniforms = ["uProjectionMatrix", "uViewMatrix", "uModelMatrix", "uColor", "uCameraPos"];
     
     expectedSphereUniforms.forEach(uniform => {
         if (sphereUniforms[uniform] === null || sphereUniforms[uniform] === undefined) {

--- a/src/edgeInfo.js
+++ b/src/edgeInfo.js
@@ -1,0 +1,139 @@
+// src/edgeInfo.js
+// Edge Information Panel Management
+
+let edgeInfoPanel = null;
+let edgeInfoContent = null;
+let edgeInfoToggle = null;
+
+// Initialize the edge information panel
+function initializeEdgeInfoPanel() {
+    try {
+        edgeInfoPanel = document.getElementById('edgeInfoPanel');
+        edgeInfoContent = document.getElementById('edgeInfoContent');
+        edgeInfoToggle = document.getElementById('edgeInfoToggle');
+        
+        if (!edgeInfoPanel) {
+            console.error('Edge info panel element not found!');
+            return;
+        }
+        
+        // Set up toggle functionality
+        const edgeInfoHeader = document.getElementById('edgeInfoHeader');
+        if (edgeInfoHeader) {
+            edgeInfoHeader.addEventListener('click', toggleEdgeInfoPanel);
+        }
+        
+        // Initially hide the panel
+        hideEdgeInfoPanel();
+        
+        console.log('Edge info panel initialized successfully');
+    } catch (error) {
+        console.error('Error initializing edge info panel:', error);
+    }
+}
+
+// Toggle the collapsed state of the edge info panel
+function toggleEdgeInfoPanel() {
+    if (edgeInfoPanel.classList.contains('collapsed')) {
+        edgeInfoPanel.classList.remove('collapsed');
+    } else {
+        edgeInfoPanel.classList.add('collapsed');
+    }
+}
+
+// Show the edge information panel
+function showEdgeInfoPanel() {
+    edgeInfoPanel.classList.remove('hidden');
+}
+
+// Hide the edge information panel
+function hideEdgeInfoPanel() {
+    edgeInfoPanel.classList.add('hidden');
+}
+
+// Get vertex type as readable string
+function getVertexTypeString(type) {
+    switch(type) {
+        case NODE_TYPES.MINIMUM: return 'Minimum';
+        case NODE_TYPES.SADDLE: return 'Saddle';
+        case NODE_TYPES.MAXIMUM: return 'Maximum';
+        case NODE_TYPES.INTERMEDIATE: return 'Intermediate';
+        default: return 'Unknown';
+    }
+}
+
+// Update the edge information display
+function updateEdgeInfo(edgeIndex) {
+    try {
+        if (!edgeIndex || !edges || edgeIndex < 1 || edgeIndex > edges.length) {
+            console.log('Invalid edge index or edges not available');
+            hideEdgeInfoPanel();
+            return;
+        }
+        
+        // Get the original edge (1-based to 0-based conversion)
+        const edge = edges[edgeIndex - 1];
+        const fromVertexIndex = edge[0];
+        const toVertexIndex = edge[1];
+        
+        // Get vertex information
+        const fromVertex = vertices[fromVertexIndex];
+        const toVertex = vertices[toVertexIndex];
+        const fromType = vertexTypes[fromVertexIndex];
+        const toType = vertexTypes[toVertexIndex];
+        const fromValue = vertexValues[fromVertexIndex];
+        const toValue = vertexValues[toVertexIndex];
+        
+    // Update the display
+    document.getElementById('edgeNumber').textContent = edgeIndex;
+    document.getElementById('fromVertex').textContent = `${fromVertexIndex} (${fromVertex[0].toFixed(2)}, ${fromVertex[1].toFixed(2)}, ${fromVertex[2].toFixed(2)})`;
+    document.getElementById('toVertex').textContent = `${toVertexIndex} (${toVertex[0].toFixed(2)}, ${toVertex[1].toFixed(2)}, ${toVertex[2].toFixed(2)})`;
+    document.getElementById('fromVertexType').textContent = getVertexTypeString(fromType);
+    document.getElementById('toVertexType').textContent = getVertexTypeString(toType);
+    document.getElementById('fromVertexValue').textContent = fromValue.toString();
+    document.getElementById('toVertexValue').textContent = toValue.toString();
+        
+        // Determine connection type based on vertex positions
+        const isHorizontal = Math.abs(fromVertex[1] - toVertex[1]) < 1e-6;
+        const isVertical = Math.abs(fromVertex[0] - toVertex[0]) < 1e-6 && Math.abs(fromVertex[2] - toVertex[2]) < 1e-6;
+        
+        let connectionType = 'L-shaped';
+        if (isHorizontal) {
+            connectionType = 'Horizontal';
+        } else if (isVertical) {
+            connectionType = 'Vertical';
+        }
+        
+        document.getElementById('connectionType').textContent = connectionType;
+        
+        // Show the panel
+        showEdgeInfoPanel();
+        
+        console.log(`Edge info updated for edge ${edgeIndex}: ${fromVertexIndex} -> ${toVertexIndex}`);
+    } catch (error) {
+        console.error('Error updating edge info:', error);
+        hideEdgeInfoPanel();
+    }
+}
+
+// Clear edge information (when no edge is selected)
+function clearEdgeInfo() {
+    document.getElementById('edgeNumber').textContent = '-';
+    document.getElementById('fromVertex').textContent = '-';
+    document.getElementById('toVertex').textContent = '-';
+    document.getElementById('fromVertexType').textContent = '-';
+    document.getElementById('toVertexType').textContent = '-';
+    document.getElementById('fromVertexValue').textContent = '-';
+    document.getElementById('toVertexValue').textContent = '-';
+    document.getElementById('connectionType').textContent = '-';
+    
+    hideEdgeInfoPanel();
+}
+
+// Initialize when DOM is loaded
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeEdgeInfoPanel);
+} else {
+    // DOM is already loaded
+    initializeEdgeInfoPanel();
+}

--- a/src/globalvar.js
+++ b/src/globalvar.js
@@ -7,6 +7,7 @@
 Issues with the code:
     1. The Overlapping of Spheres and Cylinders is still present.
     2. Issues with anti-aliasing on the cylinders (jagged edges).
+    3. by mapping it is possible for maxima to remain below the saddles (i.e. the saddle maxima arc length is not mapping correctly in some edge cases (Block 1 WRESNET))
 
 New Functionality (to add)
     1. Add selection logic using mouse clicks to select edges and vertices.
@@ -26,6 +27,9 @@ const gl = canvas.getContext("webgl2", {
     stencil: false,
     premultipliedAlpha: false
 });
+
+console.log('Depth bits:', gl.getParameter(gl.DEPTH_BITS));
+
 if (!gl) {
     console.error("WebGL2 not supported");
 }
@@ -38,10 +42,6 @@ let pipeColor = [0.800, 0.800, 0.800]; // Color of the pipes
 
 //Background color
 let backgroundColor = [0.9, 0.9, 0.9, 1.0]; // Dark gray background
-
-// Light position
-let lightPosition = [10, 10, 10]; // Position of the light source in the scene
-let lightColor = [1.0, 1.0, 1.0]; // Color of the light source
 
 // JS Object for point types (assgned each one a unique number)
 const NODE_TYPES = {
@@ -63,7 +63,10 @@ let NODE_COLORS = {
 
 let projectionMatrix, viewMatrix, modelMatrix, invViewMatrix;
 projectionMatrix = mat4.create();
-mat4.perspective(projectionMatrix, Math.PI / 4, canvas.width / canvas.height, 0.1, 10000);
+// mat4.perspective(projectionMatrix, Math.PI / 4, canvas.width / canvas.height, 0.01, 1000);
+
+// Temporarily use a tighter range to see if the issue persists
+mat4.perspective(projectionMatrix, Math.PI/3, canvas.width / canvas.height, 0.1, 50);
 viewMatrix = mat4.create();
 modelMatrix = mat4.create();
 mat4.identity(modelMatrix);

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -137,6 +137,10 @@ async function initializeGraph(offData) {
     // In initializeGraph function, add this at the beginning:
     intermediatePoints = []; // Clear previous intermediate points
 
+    // Clear pipe cache when loading new graph data
+    if (typeof clearPipeCache !== 'undefined') {
+        clearPipeCache();
+    }
 
     try {
         // Replace the condition check:
@@ -213,8 +217,6 @@ async function initializeGraph(offData) {
                 uProjectionMatrix: gl.getUniformLocation(sphereProgram, "uProjectionMatrix"),
                 uViewMatrix: gl.getUniformLocation(sphereProgram, "uViewMatrix"),
                 uModelMatrix: gl.getUniformLocation(sphereProgram, "uModelMatrix"),
-                uLightPos: gl.getUniformLocation(sphereProgram, "uLightPos"),
-                uLightColor: gl.getUniformLocation(sphereProgram, "uLightColor"),
                 uCameraPosLocation: gl.getUniformLocation(sphereProgram, "uCameraPos"),
                 uColorLocation: gl.getUniformLocation(sphereProgram, "uColor"),
                 uInvViewMatrix: gl.getUniformLocation(sphereProgram, "uInvViewMatrix")
@@ -222,8 +224,6 @@ async function initializeGraph(offData) {
                 uProjectionMatrix: gl.getUniformLocation(pipeProgram, "uProjectionMatrix"),
                 uViewMatrix: gl.getUniformLocation(pipeProgram, "uViewMatrix"),
                 uModelMatrix: gl.getUniformLocation(pipeProgram, "uModelMatrix"),
-                uLightPos: gl.getUniformLocation(pipeProgram, "uLightPos"),
-                uLightColor: gl.getUniformLocation(pipeProgram, "uLightColor"),
                 uCameraPos: gl.getUniformLocation(pipeProgram, "uCameraPos"),
                 uInvViewMatrix: gl.getUniformLocation(pipeProgram, "uInvViewMatrix")
             };
@@ -293,69 +293,76 @@ async function initializeGraph(offData) {
         // Set up pipe VAO
 
         // In initializeGraph, update the pipe VAO setup
-// In initializeGraph, pipe VAO setup
-if (pipeVAO) gl.deleteVertexArray(pipeVAO);
-pipeVAO = gl.createVertexArray();
-gl.bindVertexArray(pipeVAO);
+    // In initializeGraph, pipe VAO setup
+    if (pipeVAO) gl.deleteVertexArray(pipeVAO);
+    pipeVAO = gl.createVertexArray();
+    gl.bindVertexArray(pipeVAO);
 
-const pipePositionBuffer = gl.createBuffer();
-const pipeInstanceBuffer = gl.createBuffer();
-const pipeIndexBuffer = gl.createBuffer();
+    const pipePositionBuffer = gl.createBuffer();
+    const pipeInstanceBuffer = gl.createBuffer();
+    const pipeIndexBuffer = gl.createBuffer();
 
-// Position buffer
-gl.bindBuffer(gl.ARRAY_BUFFER, pipePositionBuffer);
-gl.bufferData(gl.ARRAY_BUFFER, cuboid.positions, gl.STATIC_DRAW);
-gl.enableVertexAttribArray(attributes.pipe.pipePosLoc);
-gl.vertexAttribPointer(attributes.pipe.pipePosLoc, 3, gl.FLOAT, false, 0, 0);
-gl.vertexAttribDivisor(attributes.pipe.pipePosLoc, 0);
+    // Position buffer
+    gl.bindBuffer(gl.ARRAY_BUFFER, pipePositionBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, cuboid.positions, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(attributes.pipe.pipePosLoc);
+    gl.vertexAttribPointer(attributes.pipe.pipePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.vertexAttribDivisor(attributes.pipe.pipePosLoc, 0);
 
-// Instance buffer
-gl.bindBuffer(gl.ARRAY_BUFFER, pipeInstanceBuffer);
-gl.bufferData(gl.ARRAY_BUFFER, pipeInstanceData, gl.STATIC_DRAW);
+    // Instance buffer
+    gl.bindBuffer(gl.ARRAY_BUFFER, pipeInstanceBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, pipeInstanceData, gl.STATIC_DRAW);
 
-// Instance start position
-gl.enableVertexAttribArray(attributes.pipe.pipeInstStartVertex);
-gl.vertexAttribPointer(attributes.pipe.pipeInstStartVertex, 3, gl.FLOAT, false, 68, 0);
-gl.vertexAttribDivisor(attributes.pipe.pipeInstStartVertex, 1);
+    // Instance start position
+    gl.enableVertexAttribArray(attributes.pipe.pipeInstStartVertex);
+    gl.vertexAttribPointer(attributes.pipe.pipeInstStartVertex, 3, gl.FLOAT, false, 68, 0);
+    gl.vertexAttribDivisor(attributes.pipe.pipeInstStartVertex, 1);
 
-// Instance end position
-gl.enableVertexAttribArray(attributes.pipe.pipeInstEndVertex);
-gl.vertexAttribPointer(attributes.pipe.pipeInstEndVertex, 3, gl.FLOAT, false, 68, 12);
-gl.vertexAttribDivisor(attributes.pipe.pipeInstEndVertex, 1);
+    // Instance end position
+    gl.enableVertexAttribArray(attributes.pipe.pipeInstEndVertex);
+    gl.vertexAttribPointer(attributes.pipe.pipeInstEndVertex, 3, gl.FLOAT, false, 68, 12);
+    gl.vertexAttribDivisor(attributes.pipe.pipeInstEndVertex, 1);
 
-// Instance radius
-gl.enableVertexAttribArray(attributes.pipe.pipeInstSizeLoc);
-gl.vertexAttribPointer(attributes.pipe.pipeInstSizeLoc, 1, gl.FLOAT, false, 68, 24);
-gl.vertexAttribDivisor(attributes.pipe.pipeInstSizeLoc, 1);
+    // Instance radius
+    gl.enableVertexAttribArray(attributes.pipe.pipeInstSizeLoc);
+    gl.vertexAttribPointer(attributes.pipe.pipeInstSizeLoc, 1, gl.FLOAT, false, 68, 24);
+    gl.vertexAttribDivisor(attributes.pipe.pipeInstSizeLoc, 1);
 
-// Instance color
-gl.enableVertexAttribArray(attributes.pipe.instColorLoc);
-gl.vertexAttribPointer(attributes.pipe.instColorLoc, 3, gl.FLOAT, false, 68, 28);
-gl.vertexAttribDivisor(attributes.pipe.instColorLoc, 1);
+    // Instance color
+    gl.enableVertexAttribArray(attributes.pipe.instColorLoc);
+    gl.vertexAttribPointer(attributes.pipe.instColorLoc, 3, gl.FLOAT, false, 68, 28);
+    gl.vertexAttribDivisor(attributes.pipe.instColorLoc, 1);
 
-// Joint point (L-joint cutting)
-gl.enableVertexAttribArray(attributes.pipe.pipeJointPointLoc);
-gl.vertexAttribPointer(attributes.pipe.pipeJointPointLoc, 3, gl.FLOAT, false, 68, 40);
-gl.vertexAttribDivisor(attributes.pipe.pipeJointPointLoc, 1);
+    // Joint point (L-joint cutting)
+    gl.enableVertexAttribArray(attributes.pipe.pipeJointPointLoc);
+    gl.vertexAttribPointer(attributes.pipe.pipeJointPointLoc, 3, gl.FLOAT, false, 68, 40);
+    gl.vertexAttribDivisor(attributes.pipe.pipeJointPointLoc, 1);
 
-// Cut plane normal (L-joint cutting)
-gl.enableVertexAttribArray(attributes.pipe.pipeCutNormalLoc);
-gl.vertexAttribPointer(attributes.pipe.pipeCutNormalLoc, 3, gl.FLOAT, false, 68, 52);
-gl.vertexAttribDivisor(attributes.pipe.pipeCutNormalLoc, 1);
+    // Cut plane normal (L-joint cutting)
+    gl.enableVertexAttribArray(attributes.pipe.pipeCutNormalLoc);
+    gl.vertexAttribPointer(attributes.pipe.pipeCutNormalLoc, 3, gl.FLOAT, false, 68, 52);
+    gl.vertexAttribDivisor(attributes.pipe.pipeCutNormalLoc, 1);
 
-// Joint type (L-joint cutting)
-gl.enableVertexAttribArray(attributes.pipe.pipeJointTypeLoc);
-gl.vertexAttribPointer(attributes.pipe.pipeJointTypeLoc, 1, gl.FLOAT, false, 68, 64);
-gl.vertexAttribDivisor(attributes.pipe.pipeJointTypeLoc, 1);
+    // Joint type (L-joint cutting)
+    gl.enableVertexAttribArray(attributes.pipe.pipeJointTypeLoc);
+    gl.vertexAttribPointer(attributes.pipe.pipeJointTypeLoc, 1, gl.FLOAT, false, 68, 64);
+    gl.vertexAttribDivisor(attributes.pipe.pipeJointTypeLoc, 1);
 
-// Index buffer
-gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, pipeIndexBuffer);
-gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, cuboid.indices, gl.STATIC_DRAW);
+    // Index buffer
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, pipeIndexBuffer);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, cuboid.indices, gl.STATIC_DRAW);
 
-gl.bindVertexArray(null);
+    gl.bindVertexArray(null);
 
-    // Update max attribute of edge input
-    document.getElementById('edgeSelect').max = edges.length;
+    // Initialize mouse picking system
+    if (typeof initializeMousePicking !== 'undefined') {
+        initializeMousePicking();
+        
+        // Update picking data after graph is loaded
+        if (typeof updatePickingData !== 'undefined') {
+            updatePickingData();
+        }
+    }
 
         // debugUniforms(); // Call the debugging function to check uniform locations
 

--- a/src/input.js
+++ b/src/input.js
@@ -10,6 +10,9 @@ let isDragging = false;
 let lastMouseX = 0;
 let lastMouseY = 0;
 let mouseSensitivity = 0.005; // Sensitivity for mouse movement (will be updated by parameter system)
+let mouseDownX = 0;
+let mouseDownY = 0;
+let hasMoved = false;
 
 
 // File input handler
@@ -44,12 +47,24 @@ canvas.addEventListener('mousedown', (e) => {
     isDragging = true;
     lastMouseX = e.clientX;
     lastMouseY = e.clientY;
+    mouseDownX = e.clientX;
+    mouseDownY = e.clientY;
+    hasMoved = false;
 });
 
 canvas.addEventListener('mousemove', (e) => {
     if (isDragging) {
         const deltaX = e.clientX - lastMouseX;
         const deltaY = e.clientY - lastMouseY;
+        
+        // Check if mouse has moved significantly
+        const moveDistance = Math.sqrt(
+            Math.pow(e.clientX - mouseDownX, 2) + 
+            Math.pow(e.clientY - mouseDownY, 2)
+        );
+        if (moveDistance > 5) { // 5 pixel threshold
+            hasMoved = true;
+        }
         
         // Horizontal mouse movement rotates around Y-axis (theta)
         cameraTheta -= deltaX * mouseSensitivity;
@@ -75,8 +90,15 @@ canvas.addEventListener('mousemove', (e) => {
     }
 });
 
-canvas.addEventListener('mouseup', () => {
+canvas.addEventListener('mouseup', (e) => {
+    if (isDragging && !hasMoved) {
+        // This was a click, not a drag - handle edge selection
+        if (typeof handleMousePick !== 'undefined') {
+            handleMousePick(e.clientX, e.clientY);
+        }
+    }
     isDragging = false;
+    hasMoved = false;
 });
 
 // Zoom with mouse wheel
@@ -105,7 +127,12 @@ window.addEventListener('resize', () => {
     canvas.style.width = displayWidth + 'px';
     canvas.style.height = displayHeight + 'px';
       gl.viewport(0, 0, canvas.width, canvas.height);
-    mat4.perspective(projectionMatrix, Math.PI / 4, canvas.width / canvas.height, 0.1, 100);
+    mat4.perspective(projectionMatrix, Math.PI/3, canvas.width / canvas.height, 0.1, 100);
+    
+    // Resize picking framebuffer
+    if (typeof resizePickingFramebuffer !== 'undefined') {
+        resizePickingFramebuffer(canvas.width, canvas.height);
+    }
     
     // Only render if uniforms are properly initialized
     if (pipeUniforms && sphereUniforms) {
@@ -127,25 +154,6 @@ window.addEventListener('keydown', (e) => {
 
 window.addEventListener('keyup', (e) => {
     keyState[e.key.toLowerCase()] = false;
-});
-
-document.getElementById('edgeSelect').addEventListener('input', function () {
-    const edgeNum = parseInt(this.value);
-    if (edgeNum >= 1 && edgeNum <= edges.length) {
-        selectedEdge = edgeNum;
-        showStatus(`Edge ${edgeNum} highlighted`, 'info');
-        initializeGraph(offData);
-        if (pipeUniforms && sphereUniforms) {
-            renderGraph();
-        }
-    } else {
-        selectedEdge = null;
-        showStatus(`Invalid edge number. Please enter a number between 1 and ${edges.length}`, 'error');
-        initializeGraph(offData);
-        if (pipeUniforms && sphereUniforms) {
-            renderGraph();
-        }
-    }
 });
 
 // FPS Toggle Button Handler
@@ -176,6 +184,11 @@ document.getElementById('fpsToggleButton').addEventListener('click', function ()
 });
 
 window.onload = () => {
+    // Initialize edge info panel
+    if (typeof initializeEdgeInfoPanel !== 'undefined') {
+        initializeEdgeInfoPanel();
+    }
+    
     //Load default OFF file if available
     if(offData !== "") {
         initializeGraph(offData);

--- a/src/menu.js
+++ b/src/menu.js
@@ -120,11 +120,6 @@ class MenuSystem {
             'colors.pipeColor', 
             parameterManager.getParameter('colors.pipeColor'));
         
-        // Light Color
-        this.createColorPicker(section, 'Light Color', 
-            'colors.lightColor', 
-            parameterManager.getParameter('colors.lightColor'));
-        
         // Node Colors
         const nodeSection = this.createSubSection('Node Colors', section);
         const nodeColors = parameterManager.getParameter('colors.nodeColors');

--- a/src/mousePicking.js
+++ b/src/mousePicking.js
@@ -1,0 +1,438 @@
+// src/mousePicking.js
+
+// Mouse picking system using framebuffer with unique colors for edge selection
+
+let pickingFramebuffer = null;
+let pickingTexture = null;
+let pickingDepthBuffer = null;
+let pickingShaderProgram = null;
+let pickingUniforms = {};
+let edgeColorMap = new Map(); // Maps color values to edge indices
+let pickingVAO = null;
+
+// Pre-allocated buffers to avoid recreation
+let pickingInstanceBuffer = null;
+let pickingPositionBuffer = null;
+let pickingIndexBuffer = null;
+let pickingInstanceData = null;
+
+// Initialize the picking system
+function initializeMousePicking() {
+    createPickingFramebuffer();
+    createPickingShader();
+    createPickingVAO();
+}
+
+// Create picking VAO and initialize buffers
+function createPickingVAO() {
+    if (pickingVAO) {
+        gl.deleteVertexArray(pickingVAO);
+        // Clean up old buffers
+        if (pickingInstanceBuffer) gl.deleteBuffer(pickingInstanceBuffer);
+        if (pickingPositionBuffer) gl.deleteBuffer(pickingPositionBuffer);
+        if (pickingIndexBuffer) gl.deleteBuffer(pickingIndexBuffer);
+    }
+    
+    pickingVAO = gl.createVertexArray();
+    gl.bindVertexArray(pickingVAO);
+    
+    // Create geometry buffers once
+    const cuboid = createCuboidGeometry();
+    
+    // Position buffer
+    pickingPositionBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, pickingPositionBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, cuboid.positions, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(0); // aPosition
+    gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+    gl.vertexAttribDivisor(0, 0);
+    
+    // Index buffer
+    pickingIndexBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, pickingIndexBuffer);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, cuboid.indices, gl.STATIC_DRAW);
+    
+    // Create instance buffer (will be updated when edges change)
+    pickingInstanceBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, pickingInstanceBuffer);
+    
+    // Setup vertex attributes for picking
+    gl.enableVertexAttribArray(1); // aCylStart
+    gl.vertexAttribPointer(1, 3, gl.FLOAT, false, 10 * 4, 0);
+    gl.vertexAttribDivisor(1, 1);
+
+    gl.enableVertexAttribArray(2); // aCylEnd
+    gl.vertexAttribPointer(2, 3, gl.FLOAT, false, 10 * 4, 3 * 4);
+    gl.vertexAttribDivisor(2, 1);
+
+    gl.enableVertexAttribArray(3); // aRadius
+    gl.vertexAttribPointer(3, 1, gl.FLOAT, false, 10 * 4, 6 * 4);
+    gl.vertexAttribDivisor(3, 1);
+
+    gl.enableVertexAttribArray(4); // aPickingColor
+    gl.vertexAttribPointer(4, 3, gl.FLOAT, false, 10 * 4, 7 * 4);
+    gl.vertexAttribDivisor(4, 1);
+    
+    gl.bindVertexArray(null);
+}
+
+// Create framebuffer for off-screen rendering with unique colors
+function createPickingFramebuffer() {
+    // Create framebuffer
+    pickingFramebuffer = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, pickingFramebuffer);
+
+    // Create color texture
+    pickingTexture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, pickingTexture);
+    gl.texImage2D(
+        gl.TEXTURE_2D, 0, gl.RGBA8,
+        canvas.width, canvas.height, 0,
+        gl.RGBA, gl.UNSIGNED_BYTE, null
+    );
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+    // Create depth buffer
+    pickingDepthBuffer = gl.createRenderbuffer();
+    gl.bindRenderbuffer(gl.RENDERBUFFER, pickingDepthBuffer);
+    gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT24, canvas.width, canvas.height);
+
+    // Attach to framebuffer
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, pickingTexture, 0);
+    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, pickingDepthBuffer);
+
+    // Check framebuffer completeness
+    if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) !== gl.FRAMEBUFFER_COMPLETE) {
+        console.error('Picking framebuffer is not complete!');
+    }
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+}
+
+// Create simplified shader for picking (renders each edge with unique color)
+function createPickingShader() {
+    const vertexShaderSource = `#version 300 es
+        layout(location = 0) in vec3 aPosition;
+        layout(location = 1) in vec3 aCylStart;
+        layout(location = 2) in vec3 aCylEnd;
+        layout(location = 3) in float aRadius;
+        layout(location = 4) in vec3 aPickingColor;
+
+        uniform mat4 uProjectionMatrix;
+        uniform mat4 uViewMatrix;
+        uniform mat4 uModelMatrix;
+
+        out vec3 vPickingColor;
+
+        void main() {
+            // Use the same transformation logic as the main pipe shader
+            vec3 cylStart = aCylStart;
+            vec3 cylEnd = aCylEnd;
+            vec3 cylDir = normalize(cylEnd - cylStart);
+            float cylLength = length(cylEnd - cylStart);
+            vec3 cylCenter = (cylStart + cylEnd) * 0.5;
+            
+            // Create transformation matrix to orient cuboid along cylinder direction
+            vec3 up = cylDir;
+            vec3 right;
+            
+            // Choose a perpendicular vector
+            if (abs(dot(up, vec3(0.0, 1.0, 0.0))) > 0.9) {
+                right = normalize(cross(up, vec3(1.0, 0.0, 0.0)));
+            } else {
+                right = normalize(cross(up, vec3(0.0, 1.0, 0.0)));
+            }
+            vec3 forward = normalize(cross(up, right));
+            
+            // Transformation matrix from local cuboid space to world space
+            mat3 transform = mat3(
+                right * aRadius * 2.0,     // X-axis (width)
+                up * cylLength,            // Y-axis (length along cylinder)
+                forward * aRadius * 2.0    // Z-axis (depth)
+            );
+            
+            // Transform position and translate to cylinder center
+            vec3 worldPos = cylCenter + transform * aPosition;
+            
+            gl_Position = uProjectionMatrix * uViewMatrix * uModelMatrix * vec4(worldPos, 1.0);
+            vPickingColor = aPickingColor;
+        }
+    `;
+
+    const fragmentShaderSource = `#version 300 es
+        precision highp float;
+
+        in vec3 vPickingColor;
+        out vec4 fragColor;
+
+        void main() {
+            // Simply output the picking color - no ray casting needed!
+            fragColor = vec4(vPickingColor, 1.0);
+        }
+    `;
+
+    // Compile shaders
+    const vertexShader = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vertexShader, vertexShaderSource);
+    gl.compileShader(vertexShader);
+    
+    if (!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)) {
+        console.error('Picking vertex shader compilation failed:', gl.getShaderInfoLog(vertexShader));
+        return;
+    }
+
+    const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fragmentShader, fragmentShaderSource);
+    gl.compileShader(fragmentShader);
+    
+    if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
+        console.error('Picking fragment shader compilation failed:', gl.getShaderInfoLog(fragmentShader));
+        return;
+    }
+
+    // Create shader program
+    pickingShaderProgram = gl.createProgram();
+    gl.attachShader(pickingShaderProgram, vertexShader);
+    gl.attachShader(pickingShaderProgram, fragmentShader);
+    gl.linkProgram(pickingShaderProgram);
+
+    if (!gl.getProgramParameter(pickingShaderProgram, gl.LINK_STATUS)) {
+        console.error('Picking shader program linking failed:', gl.getProgramInfoLog(pickingShaderProgram));
+        return;
+    }
+
+    // Get uniform locations
+    pickingUniforms = {
+        uProjectionMatrix: gl.getUniformLocation(pickingShaderProgram, 'uProjectionMatrix'),
+        uViewMatrix: gl.getUniformLocation(pickingShaderProgram, 'uViewMatrix'),
+        uModelMatrix: gl.getUniformLocation(pickingShaderProgram, 'uModelMatrix')
+    };
+}
+
+// Generate unique color for edge index
+function generatePickingColor(edgeIndex) {
+    // Convert edge index to RGB using a more robust method
+    // Add 1 to avoid pure black (0,0,0) which is background
+    const adjustedIndex = edgeIndex + 1;
+    
+    // Use full 24-bit color space more efficiently
+    const r = ((adjustedIndex) % 256) / 255.0;
+    const g = (Math.floor(adjustedIndex / 256) % 256) / 255.0;
+    const b = (Math.floor(adjustedIndex / 65536) % 256) / 255.0;
+    
+    return [r, g, b];
+}
+
+// Create picking instance data with unique colors for each edge
+function createPickingInstanceData(lShapedEdges) {
+    const pickingInstanceData = new Float32Array(lShapedEdges.length * 10); // start(3)+end(3)+radius(1)+color(3)
+    edgeColorMap.clear();
+
+    let offset = 0;
+    lShapedEdges.forEach((edge, index) => {
+        const originalEdgeIndex = edge.originalEdgeIndex;
+        const pickingColor = generatePickingColor(originalEdgeIndex);
+        
+        // Store the mapping from color to edge index using exact values
+        const r = Math.round(pickingColor[0] * 255);
+        const g = Math.round(pickingColor[1] * 255);
+        const b = Math.round(pickingColor[2] * 255);
+        const colorKey = `${r},${g},${b}`;
+        edgeColorMap.set(colorKey, originalEdgeIndex);
+        
+        console.log(`Edge ${originalEdgeIndex} -> Color: (${r}, ${g}, ${b})`);
+        
+        // Instance data
+        pickingInstanceData.set(edge.start, offset);                    // Start position (0-2)
+        pickingInstanceData.set(edge.end, offset + 3);                 // End position (3-5)
+        pickingInstanceData[offset + 6] = pipeRadius;            // Make radius larger for easier picking
+        pickingInstanceData.set(pickingColor, offset + 7);             // Picking color (7-9)
+        
+        offset += 10;
+    });
+
+    console.log(`Created picking data for ${lShapedEdges.length} edges`);
+    console.log('Color map:', edgeColorMap);
+    return pickingInstanceData;
+}
+
+// Update picking instance data (call only when edges change)
+function updatePickingData() {
+    if (!vertices || !edges || !vertexTypes || !vertexValues) {
+        console.warn('Graph data not available for picking data update');
+        return false;
+    }
+
+    const lShapedEdges = createLShapedConnections(vertices, edges, vertexTypes, vertexValues);
+    pickingInstanceData = createPickingInstanceData(lShapedEdges);
+    
+    // Update the buffer
+    if (pickingInstanceBuffer && pickingInstanceData) {
+        gl.bindBuffer(gl.ARRAY_BUFFER, pickingInstanceBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, pickingInstanceData, gl.DYNAMIC_DRAW);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+        return true;
+    }
+    return false;
+}
+
+// Render scene to picking framebuffer (optimized)
+function renderPickingPass() {
+    if (!pickingShaderProgram || !pickingFramebuffer || !pickingVAO) {
+        console.error('Picking system not initialized');
+        return;
+    }
+
+    if (!pickingInstanceData) {
+        console.error('Picking data not available - call updatePickingData() first');
+        return;
+    }
+
+    // Calculate number of instances
+    const instanceCount = pickingInstanceData.length / 10;
+    const cuboid = createCuboidGeometry();
+
+    // Bind picking framebuffer
+    gl.bindFramebuffer(gl.FRAMEBUFFER, pickingFramebuffer);
+    gl.viewport(0, 0, canvas.width, canvas.height);
+    
+    // Clear with black background (no selection)
+    gl.clearColor(0.0, 0.0, 0.0, 1.0);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    
+    // Use picking shader
+    gl.useProgram(pickingShaderProgram);
+    
+    // Set uniforms
+    gl.uniformMatrix4fv(pickingUniforms.uProjectionMatrix, false, projectionMatrix);
+    gl.uniformMatrix4fv(pickingUniforms.uViewMatrix, false, viewMatrix);
+    gl.uniformMatrix4fv(pickingUniforms.uModelMatrix, false, modelMatrix);
+
+    // Bind VAO and render
+    gl.bindVertexArray(pickingVAO);
+    gl.drawElementsInstanced(
+        gl.TRIANGLES,
+        cuboid.indices.length,
+        gl.UNSIGNED_SHORT,
+        0,
+        instanceCount
+    );
+
+    gl.bindVertexArray(null);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    
+    // Restore main viewport
+    gl.viewport(0, 0, canvas.width, canvas.height);
+}
+
+// Handle mouse click for edge selection (optimized GPU picking)
+function handleMousePick(mouseX, mouseY) {
+    if (!pickingFramebuffer || !edges || edges.length === 0) {
+        console.error('Mouse picking prerequisites not met');
+        return;
+    }
+
+    // Render picking pass
+    renderPickingPass();
+
+    // Convert mouse coordinates to framebuffer coordinates
+    const rect = canvas.getBoundingClientRect();
+    const x = Math.floor((mouseX - rect.left) * (canvas.width / rect.width));
+    const y = Math.floor((canvas.height - (mouseY - rect.top) * (canvas.height / rect.height))); // Flip Y coordinate
+    
+    // Read pixel at mouse position
+    gl.bindFramebuffer(gl.FRAMEBUFFER, pickingFramebuffer);
+    const pixel = new Uint8Array(4);
+    gl.readPixels(x, y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+
+    // Check if we hit an edge
+    if (pixel[0] === 0 && pixel[1] === 0 && pixel[2] === 0) {
+        // Clicked on background, deselect current selection
+        if (selectedEdge !== null) {
+            selectedEdge = null;
+            showStatus('Edge deselected', 'info');
+            
+            const edgeSelectInput = document.getElementById('edgeSelect');
+            if (edgeSelectInput) {
+                edgeSelectInput.value = '';
+            }
+            
+            if (typeof clearEdgeInfo !== 'undefined') {
+                clearEdgeInfo();
+            }
+        } else {
+            if (typeof clearEdgeInfo !== 'undefined') {
+                clearEdgeInfo();
+            }
+        }
+    } else {
+        // Convert pixel color back to edge index
+        const colorKey = `${pixel[0]},${pixel[1]},${pixel[2]}`;
+        const edgeIndex = edgeColorMap.get(colorKey);
+        
+        if (edgeIndex !== undefined) {
+            // Toggle selection behavior
+            if (selectedEdge === edgeIndex) {
+                // Same edge clicked, deselect it
+                selectedEdge = null;
+                showStatus(`Edge ${edgeIndex} deselected`, 'info');
+                
+                const edgeSelectInput = document.getElementById('edgeSelect');
+                if (edgeSelectInput) {
+                    edgeSelectInput.value = '';
+                }
+                
+                if (typeof clearEdgeInfo !== 'undefined') {
+                    clearEdgeInfo();
+                }
+            } else {
+                // Different edge clicked, select it
+                selectedEdge = edgeIndex;
+                showStatus(`Edge ${edgeIndex} selected`, 'success');
+                
+                const edgeSelectInput = document.getElementById('edgeSelect');
+                if (edgeSelectInput) {
+                    edgeSelectInput.value = edgeIndex;
+                }
+                
+                if (typeof updateEdgeInfo !== 'undefined') {
+                    updateEdgeInfo(edgeIndex);
+                }
+            }
+        } else {
+            console.warn(`No edge found for color: ${colorKey}`);
+        }
+    }
+
+    // Update pipe highlighting to reflect new selection
+    if (typeof updatePipeHighlighting !== 'undefined') {
+        updatePipeHighlighting();
+    }
+
+    // Re-render the scene with the new selection
+    if (pipeUniforms && sphereUniforms) {
+        renderGraph();
+    }
+}
+
+// Resize picking framebuffer when canvas resizes
+function resizePickingFramebuffer(width, height) {
+    if (!pickingFramebuffer) return;
+
+    gl.bindTexture(gl.TEXTURE_2D, pickingTexture);
+    gl.texImage2D(
+        gl.TEXTURE_2D, 0, gl.RGBA8,
+        width, height, 0,
+        gl.RGBA, gl.UNSIGNED_BYTE, null
+    );
+
+    gl.bindRenderbuffer(gl.RENDERBUFFER, pickingDepthBuffer);
+    gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT24, width, height);
+
+    gl.bindTexture(gl.TEXTURE_2D, null);
+    gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+}

--- a/src/parameterManager.js
+++ b/src/parameterManager.js
@@ -32,16 +32,12 @@ class ParameterManager {
             },
             colors: {
                 pipeColor: [0.8, 0.8, 0.8],
-                lightColor: [1.0, 1.0, 1.0],
                 nodeColors: {
                     minimum: [0.0, 0.4, 1.0],
                     saddle: [0.0, 1.0, 1.0],
                     maximum: [1.0, 0.0, 0.0],
                     intermediate: [0.8, 0.8, 0.8]
                 }
-            },
-            lighting: {
-                lightPosition: [10, 10, 10]
             },
             controls: {
                 mouseSensitivity: 0.005
@@ -69,16 +65,7 @@ class ParameterManager {
             pipeColor[1] = this.parameters.colors.pipeColor[1];
             pipeColor[2] = this.parameters.colors.pipeColor[2];
         }
-        if (typeof lightColor !== 'undefined') {
-            lightColor[0] = this.parameters.colors.lightColor[0];
-            lightColor[1] = this.parameters.colors.lightColor[1];
-            lightColor[2] = this.parameters.colors.lightColor[2];
-        }
-        if (typeof lightPosition !== 'undefined') {
-            lightPosition[0] = this.parameters.lighting.lightPosition[0];
-            lightPosition[1] = this.parameters.lighting.lightPosition[1];
-            lightPosition[2] = this.parameters.lighting.lightPosition[2];
-        }        if (typeof mouseSensitivity !== 'undefined' && window) {
+        if (typeof mouseSensitivity !== 'undefined' && window) {
             mouseSensitivity = this.parameters.controls.mouseSensitivity;
         }
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,5 +1,11 @@
 // src/renderer.js
 
+// Global variables for efficient edge selection
+let cachedPipeInstanceData = null; // Cache the full instance data
+let edgeToInstanceMapping = new Map(); // Map original edge index to instance indices
+let previousSelectedEdge = -1; // Track previous selection for efficient updates
+let lShapedEdgesCache = null; // Cache the L-shaped edges to avoid recalculation
+
 function calculateJunctionData(lShapedEdges, index) {
     const currentEdge = lShapedEdges[index];
     const originalEdgeIndex = currentEdge.originalEdgeIndex;
@@ -66,27 +72,53 @@ function calculateJunctionData(lShapedEdges, index) {
     };
 }
 function prepareLShapedPipeData(vertices, edges, vertexTypes, vertexValues) {
-    const lShapedEdges = createLShapedConnections(vertices, edges, vertexTypes, vertexValues);
-    const pipeInstanceData = new Float32Array(lShapedEdges.length * 17); // Extended for joint type: start(3)+end(3)+radius(1)+color(3)+jointPoint(3)+cutNormal(3)+jointType(1)
+    // If we have cached data and we're just updating selection, use it
+    if (cachedPipeInstanceData && edgeToInstanceMapping.size > 0) {
+        // Update selection in cached data efficiently
+        updateEdgeSelection(selectedEdge, previousSelectedEdge);
+        previousSelectedEdge = selectedEdge; // Update tracking
+        return { 
+            pipeInstanceData: cachedPipeInstanceData, 
+            edgeCount: cachedPipeInstanceData.length / 17 
+        };
+    }
+    
+    // Otherwise, initialize fresh data (first time or after graph change)
+    console.log('Initializing fresh pipe instance data');
+    return initializePipeInstanceData(vertices, edges, vertexTypes, vertexValues);
+}
+
+// Initialize and cache pipe instance data for efficient updates
+function initializePipeInstanceData(vertices, edges, vertexTypes, vertexValues) {
+    lShapedEdgesCache = createLShapedConnections(vertices, edges, vertexTypes, vertexValues);
+    cachedPipeInstanceData = new Float32Array(lShapedEdgesCache.length * 17);
+    edgeToInstanceMapping.clear();
 
     let offset = 0;
-    lShapedEdges.forEach((edge, index) => {
+    lShapedEdgesCache.forEach((edge, index) => {
         const originalEdgeIndex = edge.originalEdgeIndex;
-        const isSelected = selectedEdge === originalEdgeIndex;
         
-        // Basic instance data
-        pipeInstanceData.set(edge.start, offset);                              // Start position (0-2)
-        pipeInstanceData.set(edge.end, offset + 3);                           // End position (3-5)
-        pipeInstanceData[offset + 6] = pipeRadius;                            // Radius (6)
-        pipeInstanceData.set(isSelected ? [1.0, 0.0, 1.0] : pipeColor, offset + 7); // Color (7-9)
+        // Map original edge to all its L-shaped segments
+        if (!edgeToInstanceMapping.has(originalEdgeIndex)) {
+            edgeToInstanceMapping.set(originalEdgeIndex, []);
+        }
+        edgeToInstanceMapping.get(originalEdgeIndex).push(index);
+        
+        // Check if this edge should be selected initially
+        const isSelected = selectedEdge === originalEdgeIndex;
+        const edgeColor = isSelected ? [1.0, 0.0, 1.0] : pipeColor;
+        
+        // Set initial data
+        cachedPipeInstanceData.set(edge.start, offset);                              // Start position (0-2)
+        cachedPipeInstanceData.set(edge.end, offset + 3);                           // End position (3-5)
+        cachedPipeInstanceData[offset + 6] = pipeRadius;                            // Radius (6)
+        cachedPipeInstanceData.set(edgeColor, offset + 7);                          // Color with initial selection (7-9)
         
         // Joint data for L-joint cutting
-        pipeInstanceData.set(edge.jointPoint || [0.0, 0.0, 0.0], offset + 10); // Joint point (10-12)
-        pipeInstanceData.set(edge.cutPlaneNormal || [0.0, 0.0, 0.0], offset + 13); // Cut plane normal (13-15)
+        cachedPipeInstanceData.set(edge.jointPoint || [0.0, 0.0, 0.0], offset + 10); // Joint point (10-12)
+        cachedPipeInstanceData.set(edge.cutPlaneNormal || [0.0, 0.0, 0.0], offset + 13); // Cut plane normal (13-15)
         
-        // Joint type encoding for fragment shader L-joint cutting logic:
-        // 0.0=none, 1.0=horizontal-then-up, 2.0=horizontal-then-down, 
-        // 3.0=up-then-horizontal, 4.0=down-then-horizontal
+        // Joint type encoding
         let jointTypeValue = 0;
         if (edge.jointType) {
             switch (edge.jointType) {
@@ -97,12 +129,89 @@ function prepareLShapedPipeData(vertices, edges, vertexTypes, vertexValues) {
                 default: jointTypeValue = 0; break;
             }
         }
-        pipeInstanceData[offset + 16] = jointTypeValue; // Joint type (16)
+        cachedPipeInstanceData[offset + 16] = jointTypeValue; // Joint type (16)
         
         offset += 17;
     });
 
-    return { pipeInstanceData, edgeCount: lShapedEdges.length };
+    // Set the tracking variable to current selection
+    previousSelectedEdge = selectedEdge;
+
+    console.log(`Initialized cached pipe data for ${lShapedEdgesCache.length} edge segments`);
+    console.log(`Initial selected edge: ${selectedEdge}`);
+    console.log(`Edge to instance mapping:`, edgeToInstanceMapping);
+    
+    return { pipeInstanceData: cachedPipeInstanceData, edgeCount: lShapedEdgesCache.length };
+}
+
+// Efficient function to update only color data for selection changes
+function updateEdgeSelection(newSelectedEdge, previousEdge = -1) {
+    if (!cachedPipeInstanceData || !edgeToInstanceMapping) {
+        console.warn('Pipe data not cached, need full initialization');
+        return false;
+    }
+
+    console.log(`updateEdgeSelection called: ${previousEdge} -> ${newSelectedEdge}`);
+
+    const selectionColor = [1.0, 0.0, 1.0]; // Magenta for selected
+    const defaultColor = pipeColor; // Default pipe color
+    const colorUpdates = []; // Track which color regions to update
+
+    // Deselect previous edge (set to default color)
+    if (previousEdge >= 0 && edgeToInstanceMapping.has(previousEdge)) {
+        const instanceIndices = edgeToInstanceMapping.get(previousEdge);
+        console.log(`Deselecting edge ${previousEdge}, affects ${instanceIndices.length} segments`);
+        instanceIndices.forEach(instanceIndex => {
+            const colorOffset = instanceIndex * 17 + 7; // Color starts at offset 7
+            cachedPipeInstanceData[colorOffset] = defaultColor[0];     // R
+            cachedPipeInstanceData[colorOffset + 1] = defaultColor[1]; // G
+            cachedPipeInstanceData[colorOffset + 2] = defaultColor[2]; // B
+            
+            // Track this update for efficient GPU upload
+            colorUpdates.push({
+                byteOffset: colorOffset * 4, // 4 bytes per float
+                data: new Float32Array([defaultColor[0], defaultColor[1], defaultColor[2]])
+            });
+        });
+    }
+
+    // Select new edge (set to selection color)
+    if (newSelectedEdge >= 0 && edgeToInstanceMapping.has(newSelectedEdge)) {
+        const instanceIndices = edgeToInstanceMapping.get(newSelectedEdge);
+        console.log(`Selecting edge ${newSelectedEdge}, affects ${instanceIndices.length} segments`);
+        instanceIndices.forEach(instanceIndex => {
+            const colorOffset = instanceIndex * 17 + 7; // Color starts at offset 7
+            cachedPipeInstanceData[colorOffset] = selectionColor[0];     // R
+            cachedPipeInstanceData[colorOffset + 1] = selectionColor[1]; // G
+            cachedPipeInstanceData[colorOffset + 2] = selectionColor[2]; // B
+            
+            // Track this update for efficient GPU upload
+            colorUpdates.push({
+                byteOffset: colorOffset * 4, // 4 bytes per float
+                data: new Float32Array([selectionColor[0], selectionColor[1], selectionColor[2]])
+            });
+        });
+    } else if (newSelectedEdge >= 0) {
+        console.warn(`Edge ${newSelectedEdge} not found in mapping. Available edges:`, Array.from(edgeToInstanceMapping.keys()));
+    }
+
+    // Update GPU buffer with only the changed color data using bufferSubData
+    if (colorUpdates.length > 0 && pipeInstanceBuffer) {
+        gl.bindBuffer(gl.ARRAY_BUFFER, pipeInstanceBuffer);
+        
+        // Apply each color update individually for maximum efficiency
+        colorUpdates.forEach(update => {
+            gl.bufferSubData(gl.ARRAY_BUFFER, update.byteOffset, update.data);
+        });
+        
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+        
+        console.log(`Updated ${colorUpdates.length} color regions efficiently using bufferSubData`);
+    } else {
+        console.log('No color updates needed or buffer not available');
+    }
+
+    return true;
 }
 
 function updateInstanceData() {
@@ -161,6 +270,10 @@ function renderGraph() {
     gl.clearColor(backgroundColor[0], backgroundColor[1], backgroundColor[2], backgroundColor[3]);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
+    gl.enable(gl.DEPTH_TEST);
+    gl.depthFunc(gl.LESS); // or gl.LEQUAL?
+    gl.depthMask(true);
+
     const eye = calculateCameraPosition();
     const up = calculateUpVector();
     const target = [
@@ -181,12 +294,6 @@ function renderGraph() {
     }
     if (pipeUniforms.uModelMatrix) {
         gl.uniformMatrix4fv(pipeUniforms.uModelMatrix, false, modelMatrix);
-    }
-    if (pipeUniforms.uLightPos) {
-        gl.uniform3fv(pipeUniforms.uLightPos, eye); // Use camera position as light position
-    }
-    if (pipeUniforms.uLightColor) {
-        gl.uniform3fv(pipeUniforms.uLightColor, lightColor);
     }
     if (pipeUniforms.uCameraPos) {
         gl.uniform3fv(pipeUniforms.uCameraPos, eye);    
@@ -211,12 +318,6 @@ function renderGraph() {
     }
     if (sphereUniforms.uViewMatrix) {
         gl.uniformMatrix4fv(sphereUniforms.uViewMatrix, false, viewMatrix);
-    }
-    if (sphereUniforms.uLightPos) {
-        gl.uniform3fv(sphereUniforms.uLightPos, eye); // Use camera position as light position
-    }
-    if (sphereUniforms.uLightColor) {
-        gl.uniform3fv(sphereUniforms.uLightColor, lightColor);
     }
     if (sphereUniforms.uCameraPos) {
         gl.uniform3fv(sphereUniforms.uCameraPos, eye);
@@ -298,4 +399,53 @@ function renderGraphWithFPS() {
         // Single frame render
         renderGraph();
     }
+}
+
+// Function to update only pipe highlighting without full reinitialization
+function updatePipeHighlighting() {
+    if (!vertices || !edges || !vertexTypes || !vertexValues) {
+        console.warn('Graph data not available for updating pipe highlighting');
+        return;
+    }
+
+    if (!pipeInstanceBuffer) {
+        console.warn('Pipe instance buffer not available, reinitializing graph');
+        // If buffer doesn't exist, we need to reinitialize
+        if (typeof offData !== 'undefined' && offData) {
+            initializeGraph(offData);
+        }
+        return;
+    }
+
+    // Try efficient selection update first
+    const success = updateEdgeSelection(selectedEdge, previousSelectedEdge);
+    
+    if (!success) {
+        // Fallback to full recreation if efficient update failed
+        console.warn('Efficient update failed, falling back to full recreation');
+        const pipeData = prepareLShapedPipeData(vertices, edges, vertexTypes, vertexValues);
+        const pipeInstanceData = pipeData.pipeInstanceData;
+
+        // Update the existing pipe instance buffer
+        gl.bindBuffer(gl.ARRAY_BUFFER, pipeInstanceBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, pipeInstanceData, gl.STATIC_DRAW);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    
+    // Update the tracking variable
+    previousSelectedEdge = selectedEdge;
+    
+    console.log('Pipe highlighting updated successfully');
+    
+    // Trigger a re-render to show the color changes
+    renderGraphWithFPS();
+}
+
+// Clear cached data when graph changes (call when loading new file)
+function clearPipeCache() {
+    cachedPipeInstanceData = null;
+    edgeToInstanceMapping.clear();
+    lShapedEdgesCache = null;
+    previousSelectedEdge = -1;
+    console.log('Pipe cache cleared');
 }

--- a/style.css
+++ b/style.css
@@ -608,7 +608,106 @@ canvas {
     color: white;
 }
 
-/* Responsive Design for Sidebar */
+/* Edge Information Panel Styles */
+.edge-info-panel {
+    position: absolute;
+    bottom: 20px;
+    left: 20px;
+    background: rgba(255, 255, 255, 0.95);
+    border: 2px solid #673AB7;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    z-index: 200;
+    min-width: 320px;
+    max-width: 400px;
+    transition: all 0.3s ease;
+    backdrop-filter: blur(5px);
+    font-family: Arial, sans-serif;
+}
+
+.edge-info-panel.collapsed .edge-info-content {
+    display: none;
+}
+
+.edge-info-header {
+    background: #673AB7;
+    color: white;
+    padding: 12px 15px;
+    border-radius: 6px 6px 0 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    cursor: pointer;
+    user-select: none;
+}
+
+.edge-info-header:hover {
+    background: #5E35B1;
+}
+
+.edge-info-title {
+    font-weight: bold;
+    font-size: 14px;
+}
+
+.edge-info-toggle {
+    background: none;
+    border: none;
+    color: white;
+    font-size: 12px;
+    cursor: pointer;
+    padding: 2px;
+    transition: transform 0.3s ease;
+}
+
+.edge-info-panel:not(.collapsed) .edge-info-toggle {
+    transform: rotate(180deg);
+}
+
+.edge-info-content {
+    padding: 15px;
+    background: rgba(255, 255, 255, 0.98);
+    border-radius: 0 0 6px 6px;
+}
+
+.edge-info-item {
+    margin-bottom: 8px;
+    font-size: 16px;
+    color: #333;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    flex-wrap: wrap;
+}
+
+.edge-info-item:last-child {
+    margin-bottom: 0;
+}
+
+.edge-info-item strong {
+    color: #673AB7;
+    min-width: 90px;
+    font-weight: 600;
+    margin-right: 8px;
+}
+
+.edge-info-item span {
+    color: #555;
+    font-weight: 500;
+    text-align: right;
+    flex: 1;
+    word-break: break-all;
+    font-family: Arial, Helvetica, sans-serif, monospace;
+    font-size: 12px;
+    line-height: 1.3;
+}
+
+/* Hide panel when no edge is selected */
+.edge-info-panel.hidden {
+    display: none;
+}
+
+/* Responsive adjustments */
 @media (max-width: 768px) {
     .settings-sidebar {
         width: 100%;
@@ -635,6 +734,14 @@ canvas {
     
     .menu-footer {
         padding: 12px;
+    }
+
+    .edge-info-panel {
+        bottom: 10px;
+        left: 10px;
+        right: 10px;
+        min-width: auto;
+        max-width: none;
     }
 }
 


### PR DESCRIPTION
Okay
Summary of Changes:
1. Edge selecting logic using a frameBuffer that writes to a texture and makes the cuboid with different colors that can we used to selection on the basis of color reading.
2. Depth values of spheres changed on the basis of hemispherical Z values instead of ray-casting depths.
3. Added Edge info and separate collapsible box for that.
4. Removed the light positions and other uniforms and all things related to light, as the light is now attached to the camera as a headlamp and is handled in the shaders itself (in view Space).